### PR TITLE
Add DCVLR baseline analysis notebook

### DIFF
--- a/configs/projects/dcvlr/evaluation/eval.yaml
+++ b/configs/projects/dcvlr/evaluation/eval.yaml
@@ -1,0 +1,39 @@
+# Evaluation config for Qwen2-VL 7B on DCVLR benchmarks.
+#
+# Requirements:
+#   - Log into WandB (`wandb login`) or disable `enable_wandb`
+#   - Install DCVLR evaluation dependencies as described in configs/projects/dcvlr/README.md
+#
+# Usage:
+#   oumi evaluate -c configs/projects/dcvlr/evaluation/eval.yaml
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/evaluate/evaluate.html
+#   - Config class: oumi.core.configs.EvaluationConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/evaluation_config.py
+#   - Other eval configs: configs/**/evaluation/
+
+model:
+  model_name: "Qwen/Qwen2-VL-7B-Instruct"
+  model_max_length: 4096
+  torch_dtype_str: "bfloat16"
+  attn_implementation: "sdpa"
+  trust_remote_code: True
+  shard_for_eval: True
+
+generation:
+  batch_size: 1
+
+# DCVLR baseline benchmarks
+tasks:
+  - evaluation_backend: dcvlr_vlmeval
+    task_name: VMCBench_DEV
+  - evaluation_backend: dcvlr_vlmeval
+    task_name: OlympiadBench
+  - evaluation_backend: dcvlr_vlmeval
+    task_name: LiveXivVQA
+  - evaluation_backend: dcvlr_vlmeval
+    task_name: LiveXivTQA
+
+enable_wandb: True
+inference_engine: NATIVE

--- a/configs/projects/dcvlr/inference/infer.yaml
+++ b/configs/projects/dcvlr/inference/infer.yaml
@@ -1,0 +1,24 @@
+# Qwen2-VL 7B inference config for DCVLR benchmarks.
+#
+# Usage:
+#   oumi infer -i -c configs/projects/dcvlr/inference/infer.yaml \
+#     --image /path/to/image.jpg --prompt "<question>"
+#
+# See Also:
+#   - Documentation: https://oumi.ai/docs/en/latest/user_guides/infer/infer.html
+#   - Config class: oumi.core.configs.InferenceConfig
+#   - Config source: https://github.com/oumi-ai/oumi/blob/main/src/oumi/core/configs/inference_config.py
+#   - Other inference configs: configs/**/inference/
+
+model:
+  model_name: "Qwen/Qwen2-VL-7B-Instruct"
+  torch_dtype_str: "bfloat16"
+  model_max_length: 4096
+  chat_template: "qwen2-vl-instruct"
+  trust_remote_code: True
+
+generation:
+  max_new_tokens: 512
+  batch_size: 1
+
+engine: NATIVE

--- a/notebooks/DCVLR_Baseline_Analysis.ipynb
+++ b/notebooks/DCVLR_Baseline_Analysis.ipynb
@@ -1,0 +1,250 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "5f2f0748",
+   "metadata": {},
+   "source": [
+    "\n",
+    "# DCVLR Baseline Analysis Notebook\n",
+    "\n",
+    "This Colab notebook aggregates DCVLR benchmark datasets, evaluates a baseline model, and finds similar training examples for unsolved problems.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "558879e1",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## Setup\n",
+    "Install required packages. This cell is intended for Google Colab execution.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "60205a14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "!pip install -q oumi datasets transformers accelerate sentence-transformers faiss-cpu pillow\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7541f098",
+   "metadata": {},
+   "source": [
+    "## Imports and Configuration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eaca4a79",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "from datasets import load_dataset, concatenate_datasets\n",
+    "from transformers import AutoProcessor, AutoModelForVision2Seq\n",
+    "from sentence_transformers import SentenceTransformer\n",
+    "from PIL import Image\n",
+    "import torch\n",
+    "import faiss\n",
+    "import json\n",
+    "from pathlib import Path\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "46baf999",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## Load Datasets\n",
+    "This section loads the curated DCVLR training dataset and benchmark datasets, then concatenates them for evaluation.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "369c0cb4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "benchmark_datasets = [\n",
+    "    \"VMCBench_DEV\",\n",
+    "    \"OlympiadBench\",\n",
+    "    \"LiveXivVQA\",\n",
+    "    \"LiveXivTQA\",\n",
+    "]\n",
+    "\n",
+    "baseline_dataset = \"penfever/multimodal-open-r1-8192-filtered-tighter\"\n",
+    "\n",
+    "image_column = \"image\"\n",
+    "question_column = \"question\"\n",
+    "answer_column = \"answer\"\n",
+    "\n",
+    "loaded_datasets = []\n",
+    "for name in benchmark_datasets:\n",
+    "    ds = load_dataset(name, split=\"test\", trust_remote_code=True)\n",
+    "    loaded_datasets.append(ds)\n",
+    "\n",
+    "baseline_ds = load_dataset(baseline_dataset, split=\"train\", trust_remote_code=True)\n",
+    "loaded_datasets.append(baseline_ds)\n",
+    "\n",
+    "all_data = concatenate_datasets(loaded_datasets)\n",
+    "print(f\"Total samples: {len(all_data)}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a93a6b71",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## Run Inference with Qwen\n",
+    "This section runs the Qwen model on all samples. Additional models can be added by uncommenting the respective lines.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e39e7edd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "model_name = \"Qwen/Qwen2-VL-7B-Instruct\"\n",
+    "# model_name = \"ANOTHER/MODEL\"  # Uncomment to try other baseline models\n",
+    "\n",
+    "processor = AutoProcessor.from_pretrained(model_name, trust_remote_code=True)\n",
+    "model = AutoModelForVision2Seq.from_pretrained(model_name, device_map=\"auto\", trust_remote_code=True)\n",
+    "model.eval()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fc399293",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "@torch.no_grad()\n",
+    "def generate_answer(sample):\n",
+    "    question = sample[question_column]\n",
+    "    image = sample[image_column]\n",
+    "    if not isinstance(image, Image.Image):\n",
+    "        image = Image.open(image)\n",
+    "    inputs = processor(text=question, images=image, return_tensors=\"pt\").to(model.device)\n",
+    "    output = model.generate(**inputs, max_new_tokens=512)\n",
+    "    return processor.batch_decode(output, skip_special_tokens=True)[0]\n",
+    "\n",
+    "predictions = []\n",
+    "for sample in all_data:\n",
+    "    try:\n",
+    "        pred = generate_answer(sample)\n",
+    "    except Exception as e:\n",
+    "        pred = f\"ERROR: {e}\"\n",
+    "    predictions.append(pred)\n",
+    "\n",
+    "all_data = all_data.add_column(\"prediction\", predictions)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ac6d9e26",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## Evaluate and Filter Unsolved Problems\n",
+    "We mark a sample as solved when the predicted answer contains the ground truth answer as a substring (case-insensitive). Adjust the heuristic as needed.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "82121adc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "import re\n",
+    "\n",
+    "def is_correct(pred, answer):\n",
+    "    if answer is None:\n",
+    "        return False\n",
+    "    return re.search(re.escape(str(answer)), str(pred), re.IGNORECASE) is not None\n",
+    "\n",
+    "solved = [is_correct(p, a) for p, a in zip(all_data[\"prediction\"], all_data[answer_column])]\n",
+    "all_data = all_data.add_column(\"solved\", solved)\n",
+    "\n",
+    "unsolved_data = all_data.filter(lambda x: not x[\"solved\"])\n",
+    "print(f\"Solved: {sum(solved)} / {len(solved)}\")\n",
+    "print(f\"Unsolved: {len(unsolved_data)}\")\n",
+    "\n",
+    "unsolved_path = Path(\"unsolved_examples.json\")\n",
+    "unsolved_data.to_json(str(unsolved_path))\n",
+    "print(f\"Saved unsolved samples to {unsolved_path}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "96d1e7bc",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## Retrieve Similar Training Samples via Multimodal RAG\n",
+    "For each unsolved sample, we retrieve the most similar training examples using text and image embeddings.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "deb9970d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "text_encoder = SentenceTransformer(\"sentence-transformers/all-MiniLM-L6-v2\")\n",
+    "clip_name = \"openai/clip-vit-base-patch32\"\n",
+    "clip_model = AutoModelForVision2Seq.from_pretrained(clip_name)\n",
+    "clip_processor = AutoProcessor.from_pretrained(clip_name)\n",
+    "\n",
+    "\n",
+    "def embed_sample(sample):\n",
+    "    text_emb = text_encoder.encode(sample[question_column], convert_to_tensor=True)\n",
+    "    image = sample[image_column]\n",
+    "    if not isinstance(image, Image.Image):\n",
+    "        image = Image.open(image)\n",
+    "    clip_inputs = clip_processor(text=[sample[question_column]], images=image, return_tensors=\"pt\")\n",
+    "    image_emb = clip_model.get_image_features(**clip_inputs)\n",
+    "    return torch.cat([text_emb, image_emb.squeeze(0)], dim=0)\n",
+    "\n",
+    "train_embeddings = [embed_sample(sample) for sample in baseline_ds]\n",
+    "train_matrix = torch.stack(train_embeddings).cpu().numpy().astype(\"float32\")\n",
+    "index = faiss.IndexFlatIP(train_matrix.shape[1])\n",
+    "index.add(train_matrix)\n",
+    "\n",
+    "similar_examples = []\n",
+    "for sample in unsolved_data:\n",
+    "    query_emb = embed_sample(sample).unsqueeze(0).cpu().numpy().astype(\"float32\")\n",
+    "    _, idxs = index.search(query_emb, k=5)\n",
+    "    similar_examples.append(idxs[0].tolist())\n",
+    "\n",
+    "unsolved_data = unsolved_data.add_column(\"similar_training_idxs\", similar_examples)\n",
+    "unsolved_with_similar_path = Path(\"unsolved_with_similar.json\")\n",
+    "unsolved_data.to_json(str(unsolved_with_similar_path))\n",
+    "print(f\"Saved unsolved samples with similar training indices to {unsolved_with_similar_path}\")\n"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a Colab-ready notebook to evaluate DCVLR baselines
- run Qwen baseline on curated datasets and filter unsolved questions
- compute multimodal similarity to locate related training samples
- add Oumi inference and evaluation configs for Qwen2-VL on DCVLR benchmarks

## Testing
- `pre-commit run --files configs/projects/dcvlr/inference/infer.yaml configs/projects/dcvlr/evaluation/eval.yaml` *(fails: URLError: <urlopen error Tunnel connection failed: 403 Forbidden>)*

------
https://chatgpt.com/codex/tasks/task_e_68bb554f1d4083279c00382cf96b62bf